### PR TITLE
make jshintrb see local .jshintrc

### DIFF
--- a/lib/pronto/jshint.rb
+++ b/lib/pronto/jshint.rb
@@ -13,7 +13,7 @@ module Pronto
     end
 
     def inspect(patch)
-      offences = Jshintrb.lint(patch.new_file_full_path).compact
+      offences = Jshintrb.lint(patch.new_file_full_path, :jshintrc).compact
 
       offences.map do |offence|
         patch.added_lines.select { |line| line.new_lineno == offence['line'] }


### PR DESCRIPTION
This small patch adds support for having a repository-wide (or even global) .jshintrc which is then used by jshint. This way, we can configure jshint options as we like.
